### PR TITLE
Fix link from clustered records in map view to table view for timeseries API

### DIFF
--- a/databrowser/src/domain/datasets/ui/mapView/cluster/useMapViewMarkerPainting.ts
+++ b/databrowser/src/domain/datasets/ui/mapView/cluster/useMapViewMarkerPainting.ts
@@ -236,6 +236,11 @@ const handleClusterClick = async (
     features: clusterLeaves,
   });
 
+  const bbox = turf.bbox({
+    type: 'FeatureCollection',
+    features: clusterLeaves,
+  });
+
   const clusterFeature: ClusterFeature = {
     recordId: feature.id as string,
     name: feature.layer.metadata.datasetName,
@@ -245,6 +250,7 @@ const handleClusterClick = async (
     count: feature.properties.point_count,
     markers,
     convexHull,
+    bbox,
   };
 
   clusterClick(clusterFeature);

--- a/databrowser/src/domain/datasets/ui/mapView/types.ts
+++ b/databrowser/src/domain/datasets/ui/mapView/types.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import {
+  BBox,
   Feature,
   FeatureCollection,
   GeoJsonProperties,
@@ -35,6 +36,7 @@ export interface ClusterFeature extends MarkerFeature {
   count: number;
   markers: MapRecord[];
   convexHull: Feature<Polygon, GeoJsonProperties> | null;
+  bbox: BBox;
 }
 
 export interface MapRecord {


### PR DESCRIPTION
This PR fixes the link building from the map to the table view for `timeseries` style APIs (see also #689)