### PR TITLE
Adding last Event Datamodel Changes due to LTS Api Switch

### DIFF
--- a/databrowser/src/config/tourism/event/event.sharedView.ts
+++ b/databrowser/src/config/tourism/event/event.sharedView.ts
@@ -20,6 +20,7 @@ import {
   locationCategory,
   licenseInfoCategory,
   mappingCategory,
+  tagCategory,
 } from '../../builder/tourism';
 import { updatehistoryCategory } from '../../builder/tourism/updatehistory';
 import { DEFAULT_DATE_TIME_FORMAT } from '../../utils';
@@ -232,6 +233,7 @@ export const eventSharedView = (): DetailViewConfig | EditViewConfig => ({
     },
     locationCategory(),
     gpsDataCategory(),
+    tagCategory('event'),
     odhTagCategory('event'),
     licenseInfoCategory(),
     mappingCategory(),


### PR DESCRIPTION
This PR adds all new fields and removes deprecated fields of the Events Endpoint. The Interface where the Events are synced changed and some Datamodel changes were done