### PR TITLE
Update dataset search to include descriptions as well next to the dataset name

### DIFF
--- a/databrowser/src/pages/datasets/overview/OverviewListPage.vue
+++ b/databrowser/src/pages/datasets/overview/OverviewListPage.vue
@@ -666,13 +666,22 @@ const visibleDatasets = computed(() => {
   let datasets = [...metaData.value];
 
   if (filters.value.searchVal) {
-    datasets = datasets.filter((dataset) =>
-      dataset.shortname
-        .toLowerCase()
-        .includes(filters.value.searchVal.toLowerCase())
-    );
+  const searchTerm = filters.value.searchVal.toLowerCase(); // Pre-calculate lowercase search term
+  datasets = datasets.filter((dataset) =>
+    // Check if shortname includes the search term
+    (dataset.shortname
+    .toLowerCase()
+    .includes(searchTerm)
+    ) ||
+    // Check if description exists AND includes the search term
+    (dataset.description &&
+    dataset.description
+      .toLowerCase()
+      .includes(searchTerm)
+    )
+  );
   }
-
+  
   // Group filters by key
   const filterGroups: Record<string, (string | boolean)[]> = {};
   for (const filter of Object.values(filters.value.applied)) {


### PR DESCRIPTION
This PR implements the feature described [here](https://github.com/noi-techpark/opendatahub-databrowser/issues/724).
The change is that full-text searches now also include dataset descriptions, if available.

