### PR TITLE
add config for all time series latest endpoint data

### DIFF
--- a/databrowser/src/config/mobility/index.ts
+++ b/databrowser/src/config/mobility/index.ts
@@ -7,11 +7,13 @@ import { defaultMobilityTableQueryParameters } from '../../domain/datasets/ui/ta
 import { eventOriginsConfig } from './eventOrigins/eventOrigins.config';
 import { representationConfig } from './representation/representation.config';
 import { stationTypesConfig } from './stationTypes/stationTypes.config';
+import { stationTypesLatestConfig } from './stationTypesLatest/stationTypesLatest.config';
 
 export const mobilityEmbeddedDatasetConfigs = [
   eventOriginsConfig,
   representationConfig,
   stationTypesConfig,
+  stationTypesLatestConfig,
 ].map<DatasetConfig>((config) => ({
   ...config,
   views: {

--- a/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.config.ts
+++ b/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.config.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { DatasetConfig } from '../../../domain/datasets/config/types';
+import { domainWithOpenApiDocument } from '../../../domain/openApi';
+import { stationTypesLatestDescription } from './stationTypesLatest.description';
+import { stationTypesLatestViews } from './stationTypesLatest.views';
+import { stationTypesLatestRoute } from './stationTypesLatest.route';
+
+export const stationTypesLatestConfig: DatasetConfig = {
+  source: 'embedded',
+  baseUrl: domainWithOpenApiDocument.mobility.baseUrl,
+  route: stationTypesLatestRoute,
+  description: stationTypesLatestDescription,
+  views: stationTypesLatestViews,
+};

--- a/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.description.ts
+++ b/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.description.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { DatasetDescription } from '../../../domain/datasets/config/types';
+
+export const stationTypesLatestDescription: DatasetDescription = {
+  title: 'Station types',
+  subtitle: 'View station details of given stationtypes.',
+  description: 'View station details of given stationtypes.',
+};

--- a/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.listView.ts
+++ b/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.listView.ts
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { CellComponent } from '../../../domain/cellComponents/types';
+import { ListViewConfig } from '../../../domain/datasets/config/types';
+
+export const stationTypesLatestListView: ListViewConfig = {
+  elements: [
+    {
+      title: 'Station Name',
+      component: CellComponent.StringCell,
+      class: 'w-60',
+      objectMapping: { text: 'sname' },
+    },
+    {
+      title: 'Value',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'mvalue' },
+    },
+    {
+      title: 'Unit',
+      component: CellComponent.StringCell,
+      class: 'w-20',
+      objectMapping: { text: 'tunit' },
+    },
+    {
+      title: 'Measurement',
+      component: CellComponent.StringCell,
+      class: 'w-60',
+      objectMapping: { text: 'tname' },
+    },
+    {
+      title: 'Valid Time',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'mvalidtime' },
+    },
+    {
+      title: 'Timestamp',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: '_timestamp' },
+    },
+    {
+      title: 'Station Code',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'scode' },
+    },
+    {
+      title: 'Station Coordinate',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-80',
+      objectMapping: { data: 'scoordinate' },
+    },
+    {
+      title: 'Station Metadata',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-80',
+      objectMapping: { data: 'smetadata' },
+    },
+    {
+      title: 'Station Type',
+      component: CellComponent.StringCell,
+      class: 'w-40',
+      objectMapping: { text: 'stype' },
+    },
+    {
+      title: 'Measurement Type',
+      component: CellComponent.StringCell,
+      class: 'w-40',
+      objectMapping: { text: 'ttype' },
+    },
+    {
+      title: 'Measurement Description',
+      component: CellComponent.StringCell,
+      class: 'w-80',
+      objectMapping: { text: 'tdescription' },
+    },
+    {
+      title: 'Measurement Period',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'mperiod' },
+    },
+    {
+      title: 'Station Available',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'savailable' },
+    },
+    {
+      title: 'Station Active',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'sactive' },
+    },
+    {
+      title: 'Process Name',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'prname' },
+    },
+    {
+      title: 'Process Lineage',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'prlineage' },
+    },
+    {
+        title: 'Station Origin',
+        component: CellComponent.TypeBasedCell,
+        class: 'w-40',
+        objectMapping: { data: 'sorigin' },
+    },
+    {
+        title: 'Transaction Time',
+        component: CellComponent.TypeBasedCell,
+        class: 'w-60',
+        objectMapping: { data: 'mtransactiontime' },
+    },
+    {
+      title: 'Measurement Metadata',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-80',
+      objectMapping: { data: 'tmetadata' },
+    },
+    {
+      title: 'Process Version',
+      component: CellComponent.StringCell,
+      class: 'w-80',
+      objectMapping: { text: 'prversion' },
+    },
+    {
+      title: 'Parent Name',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'pname' },
+    },
+    {
+      title: 'Parent Code',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'pcode' },
+    },
+    {
+      title: 'Parent Type',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-60',
+      objectMapping: { data: 'ptype' },
+    },
+    {
+      title: 'Parent Coordinate',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-80',
+      objectMapping: { data: 'pcoordinate' },
+    },
+    {
+      title: 'Parent Metadata',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-80',
+      objectMapping: { data: 'pmetadata' },
+    },
+    {
+      title: 'Parent Origin',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'porigin' },
+    },
+    {
+      title: 'Parent Active',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'pactive' },
+    },
+    {
+      title: 'Parent Available',
+      component: CellComponent.TypeBasedCell,
+      class: 'w-40',
+      objectMapping: { data: 'pavailable' },
+    },
+  ],
+};

--- a/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.route.ts
+++ b/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.route.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { DatasetRoute } from '../../../domain/datasets/config/types';
+
+export const stationTypesLatestRoute: DatasetRoute = {
+  domain: 'mobility',
+  pathSegments: ['v2', 'flat', '{stationTypes}', '{dataTypes}', 'latest'],
+};

--- a/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.sharedView.ts
+++ b/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.sharedView.ts
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { CellComponent } from '../../../domain/cellComponents/types';
+import {
+  DetailViewConfig,
+  EditViewConfig
+} from '../../../domain/datasets/config/types';
+
+export const stationTypesLatestSharedView = ():
+  | DetailViewConfig
+  | EditViewConfig => ({
+  elements: [
+    {
+      name: 'Main data',
+      slug: 'main-data',
+      subcategories: [
+        {
+          name: 'General data',
+          properties: [
+            {
+              title: 'sname',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.sname',
+              },
+            },
+            {
+              title: 'scode',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.scode',
+              },
+            },
+            {
+              title: 'stype',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.stype',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Datastates',
+          properties: [
+            {
+              title: 'mtransactiontime',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.mtransactiontime',
+              },
+            },
+            {
+              title: '_timestamp',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0._timestamp',
+              },
+            },
+            {
+              title: 'savailable',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.savailable',
+              },
+            },
+            {
+              title: 'sactive',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.sactive',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Source and provenance',
+          properties: [
+            {
+              title: 'sorigin',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.sorigin',
+              },
+            },
+            {
+              title: 'prname',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.prname',
+              },
+            },
+            {
+              title: 'prversion',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.prversion',
+              },
+            },
+            {
+              title: 'prlineage',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.prlineage',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Metadata',
+          properties: [
+            {
+              title: 'JSON',
+              component: CellComponent.JsonCell,
+              objectMapping: { data: 'data.0.smetadata' },
+              params: { usePreformatted: 'true' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'GPS Data',
+      slug: 'gps-data',
+      subcategories: [
+        {
+          name: 'GPS Data',
+          properties: [
+            {
+              title: '',
+              component: CellComponent.GpsPointsCell,
+              objectMapping: {
+                latitude: 'data.0.scoordinate.y',
+                longitude: 'data.0.scoordinate.x',
+              },
+            },
+            {
+              title: 'srid',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.scoordinate.srid',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Map',
+          properties: [
+            {
+              title: '',
+              component: CellComponent.GpsPointMap,
+              objectMapping: {
+                latitude: 'data.0.scoordinate.y',
+                longitude: 'data.0.scoordinate.x',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Measurements',
+      slug: 'measurements',
+      subcategories: [
+        {
+          name: 'Measurement',
+          properties: [
+            {
+              title: 'Latest',
+              component: CellComponent.MeasurementsCell,
+              arrayMapping: {
+                pathToParent: 'data',
+                targetPropertyName: 'data',
+                objectMapping: {
+                  tdescription: 'tdescription',
+                  tname: 'tname',
+                  ttype: 'ttype',
+                  tunit: 'tunit',
+                  tmetadata: 'tmetadata',
+                  mvalue: 'mvalue',
+                  mvalidtime: 'mvalidtime',
+                  mperiod: 'mperiod',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Parent station',
+      slug: 'parent-station',
+      subcategories: [
+        {
+          name: 'General data',
+          properties: [
+            {
+              title: 'pname',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.pname',
+              },
+            },
+            {
+              title: 'pcode',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.pcode',
+              },
+            },
+            {
+              title: 'ptype',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.ptype',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Datastates',
+          properties: [
+            {
+              title: 'pavailable',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.pavailable',
+              },
+            },
+            {
+              title: 'pactive',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.pactive',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Source and provenance',
+          properties: [
+            {
+              title: 'porigin',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.porigin',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Metadata',
+          properties: [
+            {
+              title: 'pmetadata',
+              component: CellComponent.JsonCell,
+              objectMapping: {
+                data: 'data.0.pmetadata',
+              },
+              params: { usePreformatted: 'true' },
+            },
+          ],
+        },
+        {
+          name: 'GPS Data',
+          properties: [
+            {
+              title: '',
+              component: CellComponent.GpsPointsCell,
+              objectMapping: {
+                latitude: 'data.0.pcoordinate.y',
+                longitude: 'data.0.pcoordinate.x',
+              },
+            },
+            {
+              title: 'srid',
+              component: CellComponent.StringCell,
+              objectMapping: {
+                text: 'data.0.pcoordinate.srid',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Map',
+          properties: [
+            {
+              title: '',
+              component: CellComponent.GpsPointMap,
+              objectMapping: {
+                latitude: 'data.0.pcoordinate.y',
+                longitude: 'data.0.pcoordinate.x',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.views.ts
+++ b/databrowser/src/config/mobility/stationTypesLatest/stationTypesLatest.views.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { stationTypesLatestListView } from './stationTypesLatest.listView';
+import { stationTypesLatestSharedView } from './stationTypesLatest.sharedView';
+
+export const stationTypesLatestViews = {
+  table: stationTypesLatestListView,
+  detail: stationTypesLatestSharedView(),
+};

--- a/databrowser/src/domain/datasets/location/datasetViewLocation.ts
+++ b/databrowser/src/domain/datasets/location/datasetViewLocation.ts
@@ -49,6 +49,9 @@ export const computeSingleRecordLocations = (
     delete singleRecordQuery['where'];
     delete singleRecordQuery['offset'];
     delete singleRecordQuery['limit'];
+    if (pathSegments.length > 3) {
+      params.pathSegments = pathSegments.slice(0, 3);
+    }
   }
 
   const singleRecordLocation = {


### PR DESCRIPTION
Finalized configuration for all time series latest data.  
To be precise, this configuration can now display all API calls to this endpoint "https://swagger.opendatahub.com/?url=https://mobility.api.opendatahub.com/v2/apispec#/Station%20/%20time%20series/get_v2__representation___stationTypes___dataTypes__latest" 

To review the new setup, run the data browser from this branch and inspect the following datasets:  
http://localhost:3000/dataset/table/mobility/v2/flat/EnvironmentStation/NO2-Alphasense_processed_rating/latest
http://localhost:3000/dataset/table/mobility/v2/flat/ParkingStation/*/latest
http://localhost:3000/dataset/table/mobility/v2/flat/EChargingStation/number-available/latest

