### PR TITLE
add new track map component

### DIFF
--- a/databrowser/src/components/map/geoTrackMap/GeoTrackMap.vue
+++ b/databrowser/src/components/map/geoTrackMap/GeoTrackMap.vue
@@ -1,0 +1,348 @@
+<!--
+SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+  <BaseMap :init-map="geoTrackMapInit" @map-ready="mapReady" />
+</template>
+
+<script lang="ts" setup>
+import { Map } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { onUnmounted, ref, watch } from 'vue';
+import BaseMap from '../BaseMap.vue';
+import { handleMapAttribution, initMap, getGeoJsonBounds } from '../utils';
+import { randomId } from '../../utils/random';
+
+/**
+ * Validate and format coordinate pair.
+ */
+const validateCoordinate = (lat: string | null, lon: string | null): number[] | null => {
+  if (!lat || !lon) return null;
+  
+  const latitude = parseFloat(lat);
+  const longitude = parseFloat(lon);
+  
+  if (!isNaN(latitude) && !isNaN(longitude) && 
+      latitude >= -90 && latitude <= 90 && 
+      longitude >= -180 && longitude <= 180) {
+    return [longitude, latitude];
+  }
+  return null;
+};
+/**
+ * Parse GPX data to extract coordinates.
+ */
+const parseGpxToCoordinates = (gpxData: string): number[][] => {
+  try {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(gpxData, 'application/xml');
+    
+    const parserError = xmlDoc.querySelector('parsererror');
+    if (parserError) {
+      console.error('GPX parsing error:', parserError.textContent);
+      return [];
+    }
+    
+    const coordinates: number[][] = [];
+    
+    // Get all track points (trkpt elements)
+    const trackPoints = xmlDoc.querySelectorAll('trkpt');
+    trackPoints.forEach((point) => {
+      const coord = validateCoordinate(
+        point.getAttribute('lat'),
+        point.getAttribute('lon')
+      );
+      if (coord) coordinates.push(coord);
+    });
+    
+    // Get all route points (rtept elements)
+    const routePoints = xmlDoc.querySelectorAll('rtept');
+    routePoints.forEach((point) => {
+      const coord = validateCoordinate(
+        point.getAttribute('lat'),
+        point.getAttribute('lon')
+      );
+      if (coord) coordinates.push(coord);
+    });
+    
+    // If no track or route points found, try waypoints (wpt elements)
+    if (coordinates.length === 0) {
+      const waypoints = xmlDoc.querySelectorAll('wpt');
+      waypoints.forEach((point) => {
+        const coord = validateCoordinate(
+          point.getAttribute('lat'),
+          point.getAttribute('lon')
+        );
+        if (coord) coordinates.push(coord);
+      });
+    }
+    
+    return coordinates;
+  } catch (error) {
+    console.error('Error parsing GPX data:', error);
+    return [];
+  }
+};
+
+/**
+ * Parse KML data to extract coordinates.
+ */
+const parseKmlToCoordinates = (kmlData: string): number[][] => {
+  try {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(kmlData, 'application/xml');
+    
+    const parserError = xmlDoc.querySelector('parsererror');
+    if (parserError) {
+      console.error('KML parsing error:', parserError.textContent);
+      return [];
+    }
+    
+    const coordinates: number[][] = [];
+    
+    // Get coordinates from various KML elements
+    const coordElements = xmlDoc.querySelectorAll('coordinates');
+    coordElements.forEach((coordElement) => {
+      const coordText = coordElement.textContent?.trim();
+      if (coordText) {
+        // KML coordinates format: longitude,latitude,altitude longitude,latitude,altitude
+        const coordPairs = coordText.split(/\s+/).filter(pair => pair.trim().length > 0);
+        
+        coordPairs.forEach((pair) => {
+          const parts = pair.split(',');
+          if (parts.length >= 2) {
+            const coord = validateCoordinate(parts[1], parts[0]); // KML is lon,lat
+            if (coord) coordinates.push(coord);
+          }
+        });
+      }
+    });
+        
+    return coordinates;
+  } catch (error) {
+    console.error('Error parsing KML data:', error);
+    return [];
+  }
+};
+
+/**
+ * Parse track data in various formats (GeoJSON, GPX, KML).
+ */
+const parseTrackData = (trackData: string): number[][] => {
+  if (!trackData || typeof trackData !== 'string') {
+    return [];
+  }
+  
+  const trimmedData = trackData.trim();
+  
+  // Try to parse as JSON first
+  try {
+    const jsonData = JSON.parse(trimmedData);
+    
+    // Handle API response format with Geometry property
+    if (jsonData.Geometry && jsonData.Geometry.coordinates) {
+      const geometry = jsonData.Geometry;
+      
+      if (geometry.type === 'LineString' && Array.isArray(geometry.coordinates)) {
+        return geometry.coordinates;
+      }
+      
+      if (geometry.type === 'MultiLineString' && Array.isArray(geometry.coordinates)) {
+        return geometry.coordinates.flatMap((line: number[][]) => line);
+      }
+    }
+    
+    // Handle direct GeoJSON LineString
+    if (jsonData.type === 'LineString' && jsonData.coordinates) {
+      return jsonData.coordinates;
+    }
+    
+    // Handle GeoJSON Feature with LineString geometry
+    if (jsonData.type === 'Feature' && 
+        jsonData.geometry?.type === 'LineString' && 
+        jsonData.geometry.coordinates) {
+      return jsonData.geometry.coordinates;
+    }
+    
+    // Handle MultiLineString
+    if (jsonData.type === 'MultiLineString' && jsonData.coordinates) {
+      return jsonData.coordinates.flatMap((line: number[][]) => line);
+    }
+    
+    if (jsonData.type === 'Feature' && 
+        jsonData.geometry?.type === 'MultiLineString' && 
+        jsonData.geometry.coordinates) {
+      return jsonData.geometry.coordinates.flatMap((line: number[][]) => line);
+    }
+  } catch {
+    // Not valid JSON, continue with XML formats
+  }
+  
+  // Check if it's GPX
+  if (trimmedData.includes('<gpx') || trimmedData.includes('<trkpt')) {
+    return parseGpxToCoordinates(trimmedData);
+  }
+  
+  // Check if it's KML
+  if (trimmedData.includes('<kml') || trimmedData.includes('<LineString')) {
+    return parseKmlToCoordinates(trimmedData);
+  }
+  
+  return [];
+};
+
+const props = withDefaults(
+  defineProps<{
+    trackData: string | null;
+    hideAttribution?: boolean;
+  }>(),
+  {
+    trackData: null,
+    hideAttribution: false,
+  }
+);
+
+const map = ref<Map>();
+const sourceId = `geo-track-source-${randomId()}`;
+const layerId = `geo-track-layer-${randomId()}`;
+
+const geoTrackMapInit = (mapId: string) => initMap(mapId);
+
+const addTrackToMap = (mapInstance: Map, coordinates: number[][]) => {
+  if (mapInstance.getSource(sourceId) || !coordinates.length) {
+    return;
+  }
+
+  // Validate coordinates structure
+  const validCoordinates = coordinates.filter(coord => 
+    Array.isArray(coord) && 
+    coord.length >= 2 && 
+    typeof coord[0] === 'number' && 
+    typeof coord[1] === 'number'
+  );
+
+  if (validCoordinates.length < 2) {
+    console.warn('Not enough valid coordinates to draw a line');
+    return;
+  }
+
+  // Create GeoJSON LineString from coordinates
+  const geoJsonData = {
+    type: 'Feature' as const,
+    geometry: {
+      type: 'LineString' as const,
+      coordinates: validCoordinates,
+    },
+    properties: {},
+  };
+
+  mapInstance.addSource(sourceId, {
+    type: 'geojson',
+    data: geoJsonData,
+  });
+
+  mapInstance.addLayer({
+    id: layerId,
+    type: 'line',
+    source: sourceId,
+    layout: {
+      'line-join': 'round',
+      'line-cap': 'round',
+    },
+    paint: {
+      'line-color': '#476929',
+      'line-width': 3,
+    },
+  });
+
+  // Fit map to track bounds
+  const bounds = getGeoJsonBounds({
+    type: 'LineString',
+    coordinates: validCoordinates
+  });
+  if (bounds) {
+    mapInstance.fitBounds(bounds, {
+      padding: 15,
+      duration: 0,
+    });
+  }
+};
+
+const updateTrackOnMap = (mapInstance: Map, coordinates: number[][]) => {
+  const source = mapInstance.getSource(sourceId) as maplibregl.GeoJSONSource;
+  
+  if (source && coordinates.length > 0) {
+    const geoJsonData = {
+      type: 'Feature' as const,
+      geometry: {
+        type: 'LineString' as const,
+        coordinates: coordinates,
+      },
+      properties: {},
+    };
+    
+    source.setData(geoJsonData);
+    
+    // Fit map to new track bounds
+    const bounds = getGeoJsonBounds({
+      type: 'LineString',
+      coordinates: coordinates
+    });
+    if (bounds) {
+      mapInstance.fitBounds(bounds, { padding: 15 });
+    }
+  } else if (coordinates.length > 0) {
+    addTrackToMap(mapInstance, coordinates);
+  }
+};
+
+const mapReady = (readyMap: Map) => {
+  map.value = readyMap;
+  
+  if (props.trackData) {
+    const coordinates = parseTrackData(props.trackData);
+    if (coordinates.length > 0) {
+      addTrackToMap(readyMap, coordinates);
+    }
+  }
+};
+
+// Watch for track data changes to update the map
+watch(
+  () => props.trackData,
+  (newTrackData) => {
+    const mapInstance = map.value;
+    if (!mapInstance || !mapInstance.loaded()) return;
+
+    if (newTrackData) {
+      const coordinates = parseTrackData(newTrackData);
+      updateTrackOnMap(mapInstance, coordinates);
+    } else {
+      // Remove existing track if no data
+      if (mapInstance.getLayer(layerId)) {
+        mapInstance.removeLayer(layerId);
+      }
+      if (mapInstance.getSource(sourceId)) {
+        mapInstance.removeSource(sourceId);
+      }
+    }
+  }
+);
+
+onUnmounted(() => {
+  if (map.value && map.value.getStyle()) {
+    if (map.value.getLayer(layerId)) {
+      map.value.removeLayer(layerId);
+    }
+    if (map.value.getSource(sourceId)) {
+      map.value.removeSource(sourceId);
+    }
+  }
+});
+
+// Show / hide attribution
+handleMapAttribution(map, props.hideAttribution);
+</script>

--- a/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/EditGpsTrackTab.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/EditGpsTrackTab.vue
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
     <template #body="{ item, index }">
       <div class="flex flex-wrap gap-8 md:flex-nowrap">
-        <div class="basis-full md:order-1 md:basis-1/3">
+        <div class="basis-full md:order-1 md:basis-1/4">
           <SubCategoryItem title="Id" :required="true">
             <StringCell
               :text="item.Id"
@@ -53,8 +53,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             />
           </SubCategoryItem>
         </div>
-        <div class="basis-full md:order-3 md:basis-1/3">
-          <div v-if="editable" class="rounded border">
+
+        <div v-if="editable" class="basis-full md:order-3 md:basis-1/4">
+          <div class="rounded border">
             <div class="flex items-center justify-between bg-gray-50 px-4 py-3">
               <span class="font-semibold">Info &amp; action</span>
             </div>
@@ -80,13 +81,40 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             </div>
           </div>
         </div>
-        <div class="basis-full md:order-2 md:basis-1/3"></div>
+
+        <div
+          class="z-0 basis-full md:order-2"
+          :class="editable ? 'md:basis-2/4' : 'md:basis-2/3'"
+        >
+          <GpsTrackMapOverview
+            title="Map Preview"
+            content-has-no-padding
+            @expand="gpsTrackMap?.toggleFullscreen()"
+          >
+            <template #content>
+              <GpsTrackMap
+                v-if="item.GpxTrackUrl"
+                ref="gpsTrackMap"
+                :key="item.GpxTrackUrl"
+                :track-url="item.GpxTrackUrl"
+                class="h-96"
+              />
+              <div
+                v-else
+                class="flex h-96 items-center justify-center rounded-b border border-t-0 bg-gray-50 text-sm text-gray-500"
+              >
+                Enter a URL to see the map preview.
+              </div>
+            </template>
+          </GpsTrackMapOverview>
+        </div>
       </div>
     </template>
   </EditListTab>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import IconCopy from '../../../../../components/svg/IconCopy.vue';
 import IconDelete from '../../../../../components/svg/IconDelete.vue';
 import SubCategoryItem from '../../../../datasets/ui/category/SubCategoryItem.vue';
@@ -96,6 +124,8 @@ import { useInjectEditMode } from '../../utils/editList/actions/useEditMode';
 import EditListTab from '../../utils/editList/tab/EditListTab.vue';
 import StringCell from '../stringCell/StringCell.vue';
 import { GpsTrackEntry } from './types';
+import GpsTrackMap from './GpsTrackMap.vue';
+import GpsTrackMapOverview from './GpsTrackMapOverview.vue';
 
 defineProps<{ items: GpsTrackEntry[] }>();
 
@@ -103,4 +133,6 @@ const { addItem, deleteItems, duplicateItem, updateItem } =
   useInjectActionTriggers<GpsTrackEntry>();
 
 const { editable } = useInjectEditMode();
+
+const gpsTrackMap = ref<InstanceType<typeof GpsTrackMap> | null>(null);
 </script>

--- a/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/EditGpsTrackTable.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/EditGpsTrackTable.vue
@@ -7,6 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <template>
   <EditListTable :items="items">
     <template #colGroup>
+      <col class="w-32 md:w-40" />
       <col class="w-16 md:w-24" />
       <col class="w-16 md:w-24" />
       <col class="w-32 md:w-40" />
@@ -14,6 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     </template>
 
     <template #tableHeader>
+      <TableHeaderCell>MAP</TableHeaderCell>
       <TableHeaderCell>Type</TableHeaderCell>
       <TableHeaderCell>Format</TableHeaderCell>
       <TableHeaderCell>Url</TableHeaderCell>
@@ -22,10 +24,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
     <template #tableCols="{ item }">
       <TableCell>
-        <StringCell :text="item.Format" />
+        <GpsTrackMap
+          v-if="item.GpxTrackUrl"
+          class="h-24"
+          :track-url="item.GpxTrackUrl"
+          :prevent-interaction="true"
+          :fullscreen-on-click="true"
+        />
+        <div v-else class="text-sm text-gray-500">No URL</div>
       </TableCell>
       <TableCell>
         <StringCell :text="item.Type" />
+      </TableCell>
+      <TableCell>
+        <StringCell :text="item.Format" />
       </TableCell>
       <TableCell>
         <UrlCell :text="item.GpxTrackUrl" :editable="false" />
@@ -47,8 +59,10 @@ import TableHeaderCell from '../../../../../components/table/TableHeaderCell.vue
 import EditListAddButton from '../../utils/editList/EditListAddButton.vue';
 import { useInjectActionTriggers } from '../../utils/editList/actions/useActions';
 import EditListTable from '../../utils/editList/table/EditListTable.vue';
+import StringCell from '../stringCell/StringCell.vue';
 import UrlCell from '../UrlCell/UrlCell.vue';
 import { GpsTrackEntry } from './types';
+import GpsTrackMap from './GpsTrackMap.vue';
 
 defineProps<{ items: GpsTrackEntry[] }>();
 

--- a/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/GpsTrackMap.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/GpsTrackMap.vue
@@ -1,0 +1,136 @@
+<!--
+SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+  <UseFullscreen ref="fullscreenComponent" v-slot="{ toggle, isFullscreen }">
+    <div
+      class="relative size-full bg-gray-50"
+      :class="{
+        'group flex cursor-pointer items-center justify-center bg-black/60':
+          !isFullscreen && preventInteraction,
+      }"
+      @click="onContainerClick(isFullscreen)"
+    >
+      <IconExpanded
+        v-if="preventInteraction && !isFullscreen"
+        class="absolute text-white transition-all group-hover:scale-125"
+      />
+
+      <div
+        v-if="isFullscreen"
+        class="absolute right-4 top-4 z-[999] flex items-center gap-3"
+      >
+        <ButtonCustom
+          variant="ghost"
+          size="xs"
+          class="flex size-12 items-center justify-center bg-white p-2"
+          @click="toggle()"
+        >
+          <IconClose class="cursor-pointer text-green-400" />
+        </ButtonCustom>
+      </div>
+
+      <div
+        v-if="isLoading"
+        class="flex h-full items-center justify-center"
+        :class="{ 'opacity-50': !isFullscreen && preventInteraction }"
+      >
+        <IconCycle class="animate-spin text-dialog" />
+      </div>
+      <div
+        v-else-if="error"
+        class="flex h-full items-center justify-center p-4 text-center text-sm text-red-500"
+        :class="{ 'opacity-50': !isFullscreen && preventInteraction }"
+      >
+        Could not load track data from the provided URL: {{ error.message || error }}
+      </div>
+      <div
+        v-else-if="!trackData"
+        class="flex h-full items-center justify-center p-4 text-center text-sm text-gray-500"
+        :class="{ 'opacity-50': !isFullscreen && preventInteraction }"
+      >
+        No valid track data found.
+      </div>
+      <GeoTrackMap
+        v-else
+        :key="`map_${isFullscreen}`"
+        :track-data="trackData"
+        :hide-attribution="!isFullscreen"
+        :class="{
+          'pointer-events-none opacity-50': !isFullscreen && preventInteraction,
+        }"
+      />
+    </div>
+  </UseFullscreen>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import axios from 'axios';
+import { useQuery } from '@tanstack/vue-query';
+import UseFullscreen from '../../../../../components/fullscreen/UseFullscreen.vue';
+import IconCycle from '../../../../../components/svg/IconCycle.vue';
+import ButtonCustom from '../../../../../components/button/ButtonCustom.vue';
+import IconClose from '../../../../../components/svg/IconClose.vue';
+import IconExpanded from '../../../../../components/svg/IconExpanded.vue';
+import GeoTrackMap from '../../../../../components/map/geoTrackMap/GeoTrackMap.vue';
+
+const props = withDefaults(
+  defineProps<{
+    trackUrl: string;
+    preventInteraction?: boolean;
+    fullscreenOnClick?: boolean;
+  }>(),
+  {
+    preventInteraction: false,
+    fullscreenOnClick: false,
+  }
+);
+
+// Fetch track data
+const fetchTrackData = async (url: string): Promise<string> => {
+  try {
+    const response = await axios.get(url, {
+      timeout: 10000,
+      responseType: 'text',
+    });
+    
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching track data:', error);
+    throw error;
+  }
+};
+
+// Vue Query for data fetching with caching
+const {
+  data: trackData,
+  isLoading,
+  error,
+} = useQuery({
+  queryKey: ['trackData', props.trackUrl],
+  queryFn: () => fetchTrackData(props.trackUrl),
+  enabled: computed(() => !!props.trackUrl),
+  staleTime: 5 * 60 * 1000, // 5 minutes
+  gcTime: 10 * 60 * 1000, // 10 minutes
+  retry: 2,
+});
+
+const fullscreenComponent = ref();
+
+const toggleFullscreen = () => {
+  fullscreenComponent.value.toggleFullscreen();
+};
+
+const onContainerClick = (isFullscreen: boolean) => {
+  if (isFullscreen || !props.fullscreenOnClick) {
+    return;
+  }
+  toggleFullscreen();
+};
+
+defineExpose({ toggleFullscreen });
+</script>

--- a/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/GpsTrackMapOverview.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editGpsTrackCell/GpsTrackMapOverview.vue
@@ -1,0 +1,36 @@
+<!--
+SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+  <EditGpsPointBase
+    :title="title"
+    :editable="false"
+    @expand="emit('expand')"
+  >
+    <div :class="{ 'p-4': !contentHasNoPadding }">
+      <slot name="content"></slot>
+    </div>
+  </EditGpsPointBase>
+</template>
+
+<script setup lang="ts">
+import EditGpsPointBase from '../editGpsInfoCell/EditGpsPointBase.vue';
+
+withDefaults(
+  defineProps<{
+    title?: string;
+    contentHasNoPadding?: boolean;
+  }>(),
+  {
+    title: '',
+    contentHasNoPadding: false,
+  }
+);
+
+const emit = defineEmits<{
+  (e: 'expand'): void;
+}>();
+</script>


### PR DESCRIPTION
This PR implements the new Track-Map component requested in https://github.com/noi-techpark/opendatahub-databrowser/issues/769

The current implementation consists of:
- New TrackMap component integrated into GpsTrackTable and GpsTrackTab.
- Supports GeoJSON, basic GPX, and basic KML via custom parsing, prioritizing paths and track data; if those aren’t available, it also handles waypoints.
- Visuals adapted to the Open Data Hub branding.
- No start or end markings, since the beginning and end of a file don’t always correspond to the actual start and end of a track.


<img width="1457" height="270" alt="image" src="https://github.com/user-attachments/assets/84bf8839-3503-4e21-81e8-3a761c254635" />

<img width="1471" height="589" alt="image" src="https://github.com/user-attachments/assets/479438e5-a797-41db-9eba-32766bd8615b" />

<img width="1460" height="589" alt="image" src="https://github.com/user-attachments/assets/bfed89f2-5c83-4eea-96dd-5ca8644f8fd1" />
