### PR TITLE
Feature/store user preferred language in localstore

### DIFF
--- a/databrowser/src/components/language/LanguagePicker.vue
+++ b/databrowser/src/components/language/LanguagePicker.vue
@@ -17,6 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         link.value === selected ? 'border-green-500 bg-green-500/10' : '',
       ]"
       :data-test="`desktop-language-picker-${link.value}`"
+      @click="selected = link.value"
     >
       {{ link.label }}
     </ButtonLink>
@@ -58,6 +59,10 @@ const props = withDefaults(
   }
 );
 
+const emit = defineEmits<{
+  (event: 'languageChanged', value: string): void;
+}>();
+
 const supportedLanguages = Object.values(FilterLanguage);
 
 const router = useRouter();
@@ -86,6 +91,7 @@ const selected = computed({
     const to = links.value.find((link) => link.value === value)?.to;
     if (to != null) {
       router.push(to);
+      emit('languageChanged', value);
     }
   },
 });

--- a/databrowser/src/domain/datasets/config/store/datasetBaseInfo.ts
+++ b/databrowser/src/domain/datasets/config/store/datasetBaseInfo.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useLocalStorage } from '@vueuse/core';
 import { MaybeRef, ToRefs, computed, ref, toValue } from 'vue';
+import { useUserSettings } from '../../../user/userSettings';
 import { useComputeDatasetLocation } from '../../location/datasetLocation';
 import { useComputeViewKey } from '../../view/viewKey';
 import { useDatasetConfigSourceComputations } from '../datasetConfigSource';
@@ -33,9 +33,9 @@ export const useDatasetBaseInfo = (
   // User preferred dataset language, which is stored in local storage
   // This allows the user to select a preferred language for datasets
   // and have it persist across sessions.
-  const preferredLanguage = useLocalStorage<string>(
-    'preferredDatasetLanguage',
-    'en'
+
+  const preferredLanguage = useUserSettings().getUserSettingRef<string>(
+    'preferredDatasetLanguage'
   );
 
   // Compute dataset location info

--- a/databrowser/src/domain/datasets/config/store/datasetBaseInfo.ts
+++ b/databrowser/src/domain/datasets/config/store/datasetBaseInfo.ts
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { useLocalStorage } from '@vueuse/core';
 import { MaybeRef, ToRefs, computed, ref, toValue } from 'vue';
-import { DatasetConfigSource, RouteLocation } from '../types';
 import { useComputeDatasetLocation } from '../../location/datasetLocation';
-import { useValueExtractor } from '../mapping/valueExtractor';
+import { useComputeViewKey } from '../../view/viewKey';
+import { useDatasetConfigSourceComputations } from '../datasetConfigSource';
+import { useResolveDatasetConfig } from '../load/datasetConfigResolver';
 import { useObjectValueReplacer } from '../mapping/objectValueReplacer';
 import { useStringReplacer } from '../mapping/stringReplacer';
-import { useComputeViewKey } from '../../view/viewKey';
-import { useResolveDatasetConfig } from '../load/datasetConfigResolver';
-import { useDatasetConfigSourceComputations } from '../datasetConfigSource';
+import { useValueExtractor } from '../mapping/valueExtractor';
+import { DatasetConfigSource, RouteLocation } from '../types';
 
 export const useDatasetBaseInfo = (
   routeLocation: MaybeRef<ToRefs<RouteLocation>>,
@@ -29,6 +30,14 @@ export const useDatasetBaseInfo = (
   // Compute view key
   const viewKey = useComputeViewKey(routeName);
 
+  // User preferred dataset language, which is stored in local storage
+  // This allows the user to select a preferred language for datasets
+  // and have it persist across sessions.
+  const preferredLanguage = useLocalStorage<string>(
+    'preferredDatasetLanguage',
+    'en'
+  );
+
   // Compute dataset location info
   const { datasetDomain, datasetPath, datasetQuery, datasetId, fullPath } =
     useComputeDatasetLocation({
@@ -38,6 +47,7 @@ export const useDatasetBaseInfo = (
       routePath,
       routeId,
       routeQuery,
+      preferredLanguage,
     });
 
   // Build params replacement facilities

--- a/databrowser/src/domain/datasets/config/store/datasetBaseInfoStore.ts
+++ b/databrowser/src/domain/datasets/config/store/datasetBaseInfoStore.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { useLocalStorage } from '@vueuse/core';
 import { acceptHMRUpdate, defineStore } from 'pinia';
 import { ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
+import { useUserSettings } from '../../../user/userSettings';
 import { useComputeRouteLocation } from '../../location/routeLocation';
 import { DatasetConfigSource } from '../types';
 import { useDatasetBaseInfo } from './datasetBaseInfo';
@@ -24,10 +24,10 @@ export const useDatasetBaseInfoStore = defineStore(
     // User preferred source, which is stored in local storage
     // This allows the user to select a preferred source for datasets
     // and have it persist across sessions.
-    const preferredSource = useLocalStorage<DatasetConfigSource>(
-      'preferredDatasetSource',
-      source.value
-    );
+    const preferredSource =
+      useUserSettings().getUserSettingRef<DatasetConfigSource>(
+        'preferredDatasetSource'
+      );
 
     // Compute reactive dataset base info
     const baseInfo = useDatasetBaseInfo(routeLocation, preferredSource);

--- a/databrowser/src/domain/datasets/config/types.ts
+++ b/databrowser/src/domain/datasets/config/types.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { DomainWithOpenApiDocument } from '../../openApi/types';
 import { MaybeRef } from 'vue';
+import { DomainWithOpenApiDocument } from '../../openApi/types';
 
 export interface Deprecation {
   pathToDeprecation: string;
@@ -204,6 +204,7 @@ export interface DatasetQuery {
   raw: Record<string, string | null | (string | null)[]>;
   stringified: Record<string, string>;
   default: Record<string, string>;
+  preferred?: Record<string, string>;
 }
 
 export interface DatasetLocation {

--- a/databrowser/src/domain/datasets/location/datasetLocation.ts
+++ b/databrowser/src/domain/datasets/location/datasetLocation.ts
@@ -36,6 +36,7 @@ interface ComputeDatasetLocationParams {
   routePath: RoutePath;
   routeId: RouteId;
   routeQuery: RouteQuery;
+  preferredLanguage?: string;
 }
 
 export const computeDatasetLocation = ({
@@ -45,6 +46,7 @@ export const computeDatasetLocation = ({
   routePath,
   routeId,
   routeQuery,
+  preferredLanguage,
 }: ComputeDatasetLocationParams): ComputeDatasetLocation => {
   if (datasetConfig == null || viewKey == null) {
     return {
@@ -58,9 +60,13 @@ export const computeDatasetLocation = ({
 
   const datasetDomain = computeDatasetDomain(routeDomain);
 
+  const preferredValues: Record<string, string> | undefined =
+    preferredLanguage != null ? { language: preferredLanguage } : undefined;
+
   const datasetQuery = computeDatasetQuery(
     routeQuery,
-    datasetConfig.views?.[viewKey]?.defaultQueryParams
+    datasetConfig.views?.[viewKey]?.defaultQueryParams,
+    preferredValues
   );
 
   const fullPath = computeApiFullUrl(
@@ -89,6 +95,7 @@ export const useComputeDatasetLocation = (
     const routePath = toValue(params.routePath);
     const routeId = toValue(params.routeId);
     const routeQuery = toValue(params.routeQuery);
+    const preferredLanguage = toValue(params.preferredLanguage);
 
     return computeDatasetLocation({
       datasetConfig,
@@ -97,6 +104,7 @@ export const useComputeDatasetLocation = (
       routePath,
       routeId,
       routeQuery,
+      preferredLanguage,
     });
   });
 
@@ -116,10 +124,11 @@ const computeDatasetDomain = (
 
 const computeDatasetQuery = (
   routeQuery: RouteQuery,
-  defaultValues: Record<string, string> | undefined
+  defaultValues: Record<string, string> | undefined,
+  preferredValues?: Record<string, string> | undefined
 ): DatasetQuery => {
   const def = defaultValues ?? {};
-  const raw = { ...def, ...routeQuery };
+  const raw = { ...def, ...preferredValues, ...routeQuery };
   // The array serialization depends on the current dataset domain and
   // should be configurable in the future
   const stringified = stringifyRouteQuery(raw);
@@ -128,5 +137,6 @@ const computeDatasetQuery = (
     raw,
     stringified,
     default: def,
+    preferred: preferredValues,
   };
 };

--- a/databrowser/src/domain/datasets/ui/editView/EditHint.vue
+++ b/databrowser/src/domain/datasets/ui/editView/EditHint.vue
@@ -22,11 +22,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup lang="ts">
-import { useLocalStorage } from '@vueuse/core';
 import HintCustom from '../../../../components/hint/HintCustom.vue';
 import ExternalLink from '../../../../components/link/ExternalLink.vue';
+import { useUserSettings } from '../../../user/userSettings';
 
-const showEditHint = useLocalStorage('showEditHint', true);
+const userSettings = useUserSettings();
 
-const hideHint = () => (showEditHint.value = false);
+const showEditHint = userSettings.getUserSettingRef<boolean>('showEditHint');
+
+const hideHint = () => userSettings.updateUserSetting('showEditHint', false);
 </script>

--- a/databrowser/src/domain/datasets/ui/header/DatasetHeader.vue
+++ b/databrowser/src/domain/datasets/ui/header/DatasetHeader.vue
@@ -64,6 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <LanguagePicker
         v-if="showLanguagePicker"
         :current-language="currentLanguage"
+        @language-changed="changeLanguage"
       />
     </div>
   </header>
@@ -119,5 +120,9 @@ const showLanguagePicker = computed(() => datasetDomain.value === 'tourism');
 const changeSource = (value: DatasetConfigSource) => {
   useLocalStorage<DatasetConfigSource>('preferredDatasetSource', value).value =
     value;
+};
+
+const changeLanguage = (value: string) => {
+  useLocalStorage<string>('preferredDatasetLanguage', value).value = value;
 };
 </script>

--- a/databrowser/src/domain/datasets/ui/header/DatasetHeader.vue
+++ b/databrowser/src/domain/datasets/ui/header/DatasetHeader.vue
@@ -71,13 +71,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup lang="ts">
-import { useLocalStorage } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import InputSearch from '../../../../components/input/InputSearch.vue';
 import LanguagePicker from '../../../../components/language/LanguagePicker.vue';
 import TagCustom from '../../../../components/tag/TagCustom.vue';
+import { useUserSettings } from '../../../user/userSettings';
 import { useDatasetBaseInfoStore } from '../../config/store/datasetBaseInfoStore';
 import { DatasetConfigSource } from '../../config/types';
 import { useDatasetQueryStore } from '../../location/store/datasetQueryStore';
@@ -117,12 +117,13 @@ const currentLanguage = useDatasetQueryStore().handle('language');
 
 const showLanguagePicker = computed(() => datasetDomain.value === 'tourism');
 
+const userSettings = useUserSettings();
+
 const changeSource = (value: DatasetConfigSource) => {
-  useLocalStorage<DatasetConfigSource>('preferredDatasetSource', value).value =
-    value;
+  userSettings.updateUserSetting('preferredDatasetSource', value);
 };
 
 const changeLanguage = (value: string) => {
-  useLocalStorage<string>('preferredDatasetLanguage', value).value = value;
+  userSettings.updateUserSetting('preferredDatasetLanguage', value);
 };
 </script>

--- a/databrowser/src/domain/datasets/ui/mapView/MapViewHint.vue
+++ b/databrowser/src/domain/datasets/ui/mapView/MapViewHint.vue
@@ -16,13 +16,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup lang="ts">
-import { useLocalStorage } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
 import HintCustom from '../../../../components/hint/HintCustom.vue';
+import { useUserSettings } from '../../../user/userSettings';
 
 const { t } = useI18n();
 
-const showMapViewNote = useLocalStorage('showMapViewNote', true);
+const userSettings = useUserSettings();
 
-const hideHint = () => (showMapViewNote.value = false);
+const showMapViewNote =
+  userSettings.getUserSettingRef<boolean>('showMapViewNote');
+
+const hideHint = () => userSettings.updateUserSetting('showMapViewNote', false);
 </script>

--- a/databrowser/src/domain/datasets/ui/toolBox/toolBoxStore.ts
+++ b/databrowser/src/domain/datasets/ui/toolBox/toolBoxStore.ts
@@ -2,28 +2,25 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core';
 import { acceptHMRUpdate, defineStore } from 'pinia';
-import {
-  breakpointsTailwind,
-  useBreakpoints,
-  useLocalStorage,
-} from '@vueuse/core';
+import { useUserSettings } from '../../../user/userSettings';
 
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const mdAndLarger = breakpoints.greater('md');
 
-// Using useLocalStorage to persist toolbox visibility state
-const toolboxVisibilityStorage = useLocalStorage('isToolboxVisible', true);
+// Using userSettings to persist toolbox visibility state
+const userSettings = useUserSettings();
 
 const preferredToolboxVisibility = !mdAndLarger.value
   ? 'false'
-  : toolboxVisibilityStorage.value;
+  : userSettings.getUserSetting('showToolbox');
 
 const initialState = {
   visible:
     preferredToolboxVisibility === 'false'
       ? false
-      : toolboxVisibilityStorage.value,
+      : userSettings.getUserSetting('showToolbox'),
   settings: {
     showAll: false,
     showDeprecated: false,
@@ -37,7 +34,7 @@ export const useToolBoxStore = defineStore('toolBoxStore', {
   actions: {
     toggleToolboxVisibility(isVisible: boolean) {
       this.visible = isVisible;
-      toolboxVisibilityStorage.value = isVisible;
+      userSettings.updateUserSetting('showToolbox', isVisible);
     },
   },
 });

--- a/databrowser/src/domain/user/userSettings.ts
+++ b/databrowser/src/domain/user/userSettings.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useLocalStorage } from '@vueuse/core';
+import { computed } from 'vue';
+
+type SettingKey =
+  | 'preferredDatasetSource'
+  | 'preferredDatasetLanguage'
+  | 'showEditHint'
+  | 'showHero'
+  | 'showToolbox'
+  | 'showMapViewNote';
+
+type SettingValue = string | number | boolean | null | undefined;
+
+const initialSettings: Record<SettingKey, SettingValue> = {
+  preferredDatasetSource: 'embedded',
+  preferredDatasetLanguage: 'en',
+  showEditHint: true,
+  showHero: true,
+  showToolbox: true,
+  showMapViewNote: true,
+};
+
+const userSettings = useLocalStorage<Record<SettingKey, SettingValue>>(
+  'userSettings',
+  initialSettings
+);
+
+// Initialize user settings with default values if not already set
+userSettings.value = {
+  ...initialSettings,
+  ...userSettings.value,
+};
+
+export const useUserSettings = () => {
+  // This hook can be used to manage user settings stored in local storage.
+  const getUserSettings = () => {
+    return userSettings.value;
+  };
+
+  const getUserSetting = <T = SettingValue>(key: SettingKey) => {
+    return userSettings.value[key] as T;
+  };
+
+  const getUserSettingRef = <T = SettingValue>(key: SettingKey) => {
+    return computed(() => userSettings.value[key] as T);
+  };
+
+  const setUserSettings = (settings: Record<SettingKey, SettingValue>) => {
+    userSettings.value = settings || {};
+  };
+
+  const updateUserSetting = (key: SettingKey, value: SettingValue) => {
+    const settings = getUserSettings();
+    settings[key] = value;
+    setUserSettings(settings);
+  };
+
+  return {
+    getUserSettings,
+    getUserSetting,
+    getUserSettingRef,
+    setUserSettings,
+    updateUserSetting,
+  };
+};

--- a/databrowser/src/pages/datasets/overview/OverviewListPageHero.vue
+++ b/databrowser/src/pages/datasets/overview/OverviewListPageHero.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <template>
-  <section v-if="!hide" class="bg-gray-50">
+  <section v-if="showHero" class="bg-gray-50">
     <ContentAlignmentX
       class="relative m-auto flex flex-col items-start py-8 xl:w-default"
     >
@@ -32,12 +32,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <script setup lang="ts">
 import ButtonLink from '../../../components/button/ButtonLink.vue';
 import ContentAlignmentX from '../../../components/content/ContentAlignmentX.vue';
-import { useLocalStorage } from '@vueuse/core';
+import { useUserSettings } from '../../../domain/user/userSettings';
 import DisclaimerCloseHeroPopup from './DisclaimerCloseHeroPopup.vue';
 
-const hide = useLocalStorage('opendatahub-hide-hero', false);
+const userSettings = useUserSettings();
+
+const showHero = userSettings.getUserSettingRef<boolean>('showHero');
 
 const onHide = () => {
-  hide.value = true;
+  userSettings.updateUserSetting('showHero', false);
 };
 </script>


### PR DESCRIPTION
This PR implements user settings storage in the browser local storage. That way, e.g. the user chosen language will be preserved on all navigation changes (see #748).